### PR TITLE
Creating subgroups and assigning new colors from designfile

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,20 +8,72 @@ const config: Config = {
   ],
   theme: {
     extend: {
-colors: {
-  primary: '#ffb300',
-  secondary: '#f00',
-  tertiary: '#0f0',
-  black: '#181100', // 95-98% black
-  black80: '#00000080', // 80% black
-  black50: '#00000050', // 50% black
-  white: '#ffffff', // 95-98% white
-  white80: '#ffffff80', // 80% white
-  white50: '#ffffff50', // 50% white
-
-}
-    },
+      colors: {
+        // Button and interface colors
+        button: {
+          'primary': {
+            DEFAULT: '#007FE8',
+            dark: '#007FE8'
+          },
+          'secondary': {
+            DEFAULT: '#00437B',
+            dark: '#00437B'
+          },
+          'tertiary': {
+            DEFAULT: '#D2DAEE',
+            dark: '#D2DAEE'
+          },
+          'success': {
+            DEFAULT: '#6DC995',
+            dark: '#6DC995'
+          },
+          'info': {
+            DEFAULT: '#6B4897',
+            dark: '#6B4897'
+          },
+          'warning': {
+            DEFAULT: '#FF7D04',
+            dark: '#FF7D04'
+          },
+          'error': {
+            DEFAULT: '#B3001B',
+            dark: '#B3001B'
+          },
+        },
+        // Elements and backgrounds
+        element: {
+          'primary': {
+            DEFAULT: '#D2DAEE',
+            dark: '#1E3255'
+          },
+          'secondary': {
+            DEFAULT: '#3A91AA',
+            dark: '#3A91AA'
+          },
+          'tertiary': {
+            DEFAULT: '#1E3255',
+            dark: '#D2DAEE'
+          }
+        },
+        // Textboxes
+        textbox: {
+          'primary': {
+            DEFAULT: '#fff',
+            dark: '#000'
+          },
+          'secondary': {
+            DEFAULT: '#ffffff80',
+            dark: '#00000080'
+          },
+          'tertiary': {
+            DEFAULT: '#ffffff50',
+            dark: '#00000050'
+          }
+        },
+      }
+    }
   },
   plugins: [],
 };
+
 export default config;


### PR DESCRIPTION
resolves #54  by adding colors from #47 [figma](https://www.figma.com/design/CDxFU5WZQ3pkWZFBpDl5lm)

Classnames will now include its type e.g; `bg-button-primary` or `bg-element-secondary`. This will default to a light version of the element, however if you have preffer dark theme then you'll see the dark version of the element. Until we have a working dark-mode toggle button you have to keep this difference in mind.